### PR TITLE
remove final modifier to remove compiler error

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ shadowJar {
 ### Code
 In your plugin
 ```java
-private static final TimingManager timingManager;
+private static TimingManager timingManager;
 public void onEnable() {
     timingManager = TimingManager.of(this);
 }


### PR DESCRIPTION
fields need to be initialized in the constructor or directly.